### PR TITLE
Update src/fr/neatmonster/nocheatplus/checks/chat/NoPwnage.java

### DIFF
--- a/src/fr/neatmonster/nocheatplus/checks/chat/NoPwnage.java
+++ b/src/fr/neatmonster/nocheatplus/checks/chat/NoPwnage.java
@@ -158,10 +158,16 @@ public class NoPwnage extends Check {
         boolean[] results = null;
         if (event instanceof AsyncPlayerChatEvent) {
             final AsyncPlayerChatEvent e = (AsyncPlayerChatEvent) event;
+            if (e.isCancelled()) {
+                return true;
+            }
             results = unsafeCheck(player, e.getMessage(), isMainThread, cc, data);
             e.setCancelled(results[0]);
         } else if (event instanceof PlayerCommandPreprocessEvent) {
             final PlayerCommandPreprocessEvent e = (PlayerCommandPreprocessEvent) event;
+            if (e.isCancelled()) {
+                return true;
+            }
             results = unsafeCheck(player, e.getMessage(), isMainThread, cc, data);
             e.setCancelled(results[0]);
         }


### PR DESCRIPTION
If I got this correct, this is a fix that my server absolutely needs. NoCheatPlus uncancels commands, at least it's the only plugin logging at LOWEST priority and when it is called after the plugin that wants to cancel, it uncancels based on this code.

I am not sure about the return code I did there, what it does, but as a matter of fact, you should not set the e.setCancelled to a value that was true to false :/
