### PR TITLE
Don't check events if they are injected by other plugins.

### DIFF
--- a/src/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
+++ b/src/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
@@ -75,6 +75,7 @@ public class BlockBreakListener implements Listener {
          * |____/|_|\___/ \___|_|\_\ |____/|_|  \___|\__,_|_|\_\
          */
 //    	System.out.println("Break("+event.isCancelled()+"): " + event.getBlock());
+        if (event.getClass != BlockBreakEvent.class) return;
     	// Cancelled events only leads to resetting insta break.
     	if (event.isCancelled()){
     		isInstaBreak = false;


### PR DESCRIPTION
Because we have some problems with Runecraft's Power Pick, I suggest that you add a check if the event comes from Bukkit or an other plugin. If it comes from an other plugin, assume it is fine that this block is broken.

Background: Some Plugins  (like Runecraft, McMMO...)  needs to destroy blocks on the behalf of a player. They will inject own events to check if a block can be broken (to obey protections), and break it afterwards.

McMMO: if the super pickaxe is activated, instant break of blocks that can be mined.
Runecraft: when a block is broken with an (powerpick) enchanted Pickaxe, break all blocks of the same type arround it (in an 3x3 area).

This leads to many violations (noswing, not visible, etc). that can even lead to a kick.
