### PR TITLE
Fix issue with npclib

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/DataManager.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/DataManager.java
@@ -452,7 +452,7 @@ public class DataManager implements Listener, INotifyReload, INeedConfig, Compon
 					missing ++;
 					// TODO: Add the player [problem: messy NPC plugins?]?
 				}
-				if (player != this.onlinePlayers.get(name)){
+				if (!player.equals(this.onlinePlayers.get(name))){
 					changed ++;
 					// Update the reference.
 					addOnlinePlayer(player);


### PR DESCRIPTION
Using npclib to generate fakeplayers would result in the datamon getting upset. Looks like the comperator was not getting called properly without actually using the equals function.
