### PR TITLE
Fix the direction check

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
@@ -362,7 +362,7 @@ public class FightListener extends CheckListener implements JoinLeaveListener{
             }
             // TODO: Efficiency: don't check at all, if strict and !thisPassed.
             if (directionEnabled && (reachPassed || !directionPassed)) {
-                if (direction.loopCheck(player, damagedLoc, damaged, entry, directionContext, data, cc)) {
+                if (direction.loopCheck(player, loc, damaged, entry, directionContext, data, cc)) {
                     thisPassed = false;
                 } else {
                     directionPassed = true;


### PR DESCRIPTION
Fixes a bug that was introduced in 6ed52ffda65cc7ad80efba113fcb381494629cad which breaks the fight.direction check.  The damaged player's location is passed instead of the attacker's location.