### PR TITLE
Fix the angle check for hits that arrive in the same millisecond

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Angle.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Angle.java
@@ -48,9 +48,19 @@ public class Angle extends Check {
         	}
         }
 
+        long currentTimeMillis = System.currentTimeMillis();
+
+        //Check if something exists for the current time
+        if(data.angleHits.containsKey(currentTimeMillis)) {
+            //We already have a hit this millisecond so we're going to force a violation
+            data.angleHits.put(currentTimeMillis, player.getLocation()); // This needs to be a copy at present.
+            data.angleVL += 50;
+            return executeActions(player, data.angleVL, 50, cc.angleActions);
+        }
+
         // Add the new location to the map.
         // TODO: Alter method to store something less fat.
-        data.angleHits.put(System.currentTimeMillis(), player.getLocation()); // This needs to be a copy at present.
+        data.angleHits.put(currentTimeMillis, player.getLocation()); // This needs to be a copy at present.
 
         // Not enough data to calculate deltas.
         if (data.angleHits.size() < 2)

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Direction.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Direction.java
@@ -134,11 +134,11 @@ public class Direction extends Check {
 
         final double off;
         if (cc.directionStrict){
-            off = TrigUtil.combinedDirectionCheck(loc, player.getEyeHeight(), context.direction, dLoc.x, dLoc.y + context.damagedHeight / 2D, dLoc.z, context.damagedWidth, context.damagedHeight, TrigUtil.DIRECTION_PRECISION, 80.0);
+            off = TrigUtil.combinedDirectionCheck(loc, player.getEyeHeight(), context.direction, dLoc.x, dLoc.y + context.damagedHeight / 2D, dLoc.z, context.damagedWidth, context.damagedHeight, 0.5, 80.0);
         }
         else{
             // Also take into account the angle.
-            off = TrigUtil.directionCheck(loc, player.getEyeHeight(), context.direction, dLoc.x, dLoc.y + context.damagedHeight / 2D, dLoc.z, context.damagedWidth, context.damagedHeight, TrigUtil.DIRECTION_PRECISION);
+            off = TrigUtil.directionCheck(loc, player.getEyeHeight(), context.direction, dLoc.x, dLoc.y + context.damagedHeight / 2D, dLoc.z, context.damagedWidth, context.damagedHeight, 0.5);
         }
 
         if (off > 0.1) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
@@ -339,7 +339,7 @@ public class FightListener extends CheckListener implements JoinLeaveListener{
         final ReachContext reachContext = reachEnabled ? reach.getContext(player, loc, damaged, damagedLoc, data, cc, sharedContext) : null;
         final DirectionContext directionContext = directionEnabled ? direction.getContext(player, loc, damaged, damagedLoc, data, cc, sharedContext) : null;
 
-        final long traceOldest = tick - 10; // - damagedTrace.getMaxSize(); // TODO: Set by window.
+        final long traceOldest = tick - 15; // - damagedTrace.getMaxSize(); // TODO: Set by window.
         // TODO: Iterating direction, which, static/dynamic choice.
         final Iterator<TraceEntry> traceIt = damagedTrace.maxAgeIterator(traceOldest);
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
@@ -339,7 +339,7 @@ public class FightListener extends CheckListener implements JoinLeaveListener{
         final ReachContext reachContext = reachEnabled ? reach.getContext(player, loc, damaged, damagedLoc, data, cc, sharedContext) : null;
         final DirectionContext directionContext = directionEnabled ? direction.getContext(player, loc, damaged, damagedLoc, data, cc, sharedContext) : null;
 
-        final long traceOldest = tick; // - damagedTrace.getMaxSize(); // TODO: Set by window.
+        final long traceOldest = tick - 10; // - damagedTrace.getMaxSize(); // TODO: Set by window.
         // TODO: Iterating direction, which, static/dynamic choice.
         final Iterator<TraceEntry> traceIt = damagedTrace.maxAgeIterator(traceOldest);
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -796,7 +796,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
                 final Location ref = player.getVehicle().getLocation(useLoc);
                 mData.resetPositions(ref);
                 useLoc.setWorld(null);
-                mData.updateTrace(player, ref, time);
+                MovingData.getData(player).updateTrace(player, to, time);
             }
             else if (!fromWorldName.equals(toWorldName)) {
                 mData.resetPositions(to);


### PR DESCRIPTION
Hits were being added to the angleHits map unconditionally and without checking if the key already existed.  My solution is to force a violation when two hits arrive in the same millisecond.