### PR TITLE
Recognise NCPCompatSpigotCB1_11_R1 in spigot1_11_r1 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
 			</activation>
 			<modules>
 				<!-- Non minimal below. -->
-				<module>NCPCompatCBDev</module>
+				<module>NCPCompatSpigotCB1_11_R1</module>
 				<!-- Non minimal above. -->
 			</modules>
 		</profile>


### PR DESCRIPTION
Fixes ci.ender.zone and other builds that don't build using the `all` profile.