### PR TITLE
EqualsRotate Check

### DIFF
--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/EqualsRotateAdapter.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/EqualsRotateAdapter.java
@@ -29,6 +29,7 @@ public class EqualsRotateAdapter extends BaseAdapter {
 
     @Override
     public void onPacketReceiving(final PacketEvent event) {
+        final long time = System.currentTimeMillis();
         final Player player = event.getPlayer();
         if(player == null)return;
         final NetData netData = dataFactory.getData(player);
@@ -36,7 +37,7 @@ public class EqualsRotateAdapter extends BaseAdapter {
         final StructureModifier<Float> floats = event.getPacket().getFloat();
         final float yaw = floats.read(0);
         final float pitch = floats.read(1);
-        if(cc.equalsRotateActive && EQUALSROTATE.check(player, netData, cc, yaw, pitch)){
+        if(cc.equalsRotateActive && EQUALSROTATE.check(time, player, netData, cc, yaw, pitch)){
             event.setCancelled(true);
         }
     }

--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/EqualsRotateAdapter.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/EqualsRotateAdapter.java
@@ -1,0 +1,43 @@
+package fr.neatmonster.nocheatplus.checks.net.protocollib;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.reflect.StructureModifier;
+import fr.neatmonster.nocheatplus.NCPAPIProvider;
+import fr.neatmonster.nocheatplus.checks.net.EqualsRotate;
+import fr.neatmonster.nocheatplus.checks.net.NetConfig;
+import fr.neatmonster.nocheatplus.checks.net.NetData;
+import fr.neatmonster.nocheatplus.config.ConfPaths;
+import fr.neatmonster.nocheatplus.config.ConfigManager;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Arrays;
+
+public class EqualsRotateAdapter extends BaseAdapter {
+
+    private final EqualsRotate EQUALSROTATE = new EqualsRotate();
+
+    public EqualsRotateAdapter(Plugin plugin) {
+        super(plugin, ListenerPriority.LOW, PacketType.Play.Client.POSITION_LOOK, PacketType.Play.Client.LOOK);
+        if (ConfigManager.isTrueForAnyConfig(ConfPaths.NET_EQALSROTATE_ACTIVE)) {
+            NCPAPIProvider.getNoCheatPlusAPI().addFeatureTags("checks", Arrays.asList(EqualsRotate.class.getSimpleName()));
+        }
+        NCPAPIProvider.getNoCheatPlusAPI().addComponent(EQUALSROTATE);
+    }
+
+    @Override
+    public void onPacketReceiving(final PacketEvent event) {
+        final Player player = event.getPlayer();
+        if(player == null)return;
+        final NetData netData = dataFactory.getData(player);
+        final NetConfig cc = configFactory.getConfig(player);
+        final StructureModifier<Float> floats = event.getPacket().getFloat();
+        final float yaw = floats.read(0);
+        final float pitch = floats.read(1);
+        if(cc.equalsRotateActive && EQUALSROTATE.check(player, netData, cc, yaw, pitch)){
+            event.setCancelled(true);
+        }
+    }
+}

--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/KeepAliveAdapter.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/KeepAliveAdapter.java
@@ -63,6 +63,7 @@ public class KeepAliveAdapter extends BaseAdapter {
             event.setCancelled(true);
             return;
         }
+
         // Always update last received time.
         final PlayerData pData = DataManager.getPlayerData(player);
         final NetData data = dataFactory.getData(player);

--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/ProtocolLibComponent.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/ProtocolLibComponent.java
@@ -125,6 +125,9 @@ public class ProtocolLibComponent implements IDisableListener, INotifyReload, Jo
             register("fr.neatmonster.nocheatplus.checks.net.protocollib.SoundDistance", plugin);
         }
         if (ConfigManager.isAlmostTrueForAnyConfig(ConfPaths.NET_PACKETFREQUENCY_ACTIVE, ServerVersion.compareMinecraftVersion("1.9") < 0, false)) {
+            register("fr.neatmonster.nocheatplus.checks.net.protocollib.KeepAliveAdapter", plugin);
+        }
+        if (ConfigManager.isTrueForAnyConfig(ConfPaths.NET_EQALSROTATE_ACTIVE)) {
             register("fr.neatmonster.nocheatplus.checks.net.protocollib.CatchAllAdapter", plugin);
         }
         if (!registeredPacketAdapters.isEmpty()) {

--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/ProtocolLibComponent.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/ProtocolLibComponent.java
@@ -125,10 +125,10 @@ public class ProtocolLibComponent implements IDisableListener, INotifyReload, Jo
             register("fr.neatmonster.nocheatplus.checks.net.protocollib.SoundDistance", plugin);
         }
         if (ConfigManager.isAlmostTrueForAnyConfig(ConfPaths.NET_PACKETFREQUENCY_ACTIVE, ServerVersion.compareMinecraftVersion("1.9") < 0, false)) {
-            register("fr.neatmonster.nocheatplus.checks.net.protocollib.KeepAliveAdapter", plugin);
+            register("fr.neatmonster.nocheatplus.checks.net.protocollib.CatchAllAdapter", plugin);
         }
         if (ConfigManager.isTrueForAnyConfig(ConfPaths.NET_EQALSROTATE_ACTIVE)) {
-            register("fr.neatmonster.nocheatplus.checks.net.protocollib.CatchAllAdapter", plugin);
+            register("fr.neatmonster.nocheatplus.checks.net.protocollib.EqualsRotateAdapter", plugin);
         }
         if (!registeredPacketAdapters.isEmpty()) {
             List<String> names = new ArrayList<String>(registeredPacketAdapters.size());

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/CheckType.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/CheckType.java
@@ -126,7 +126,7 @@ public enum CheckType {
     NET_KEEPALIVEFREQUENCY(NET, Permissions.NET_KEEPALIVEFREQUENCY),
     NET_PACKETFREQUENCY(NET, Permissions.NET_PACKETFREQUENCY),
     NET_SOUNDDISTANCE(NET), // Can not exempt players from this one.
-
+    NET_EQUALSROTATE(NET, Permissions.NET_EQUALSROTATE)
     ;
 
     public static enum CheckTypeType {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/SelfHit.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/SelfHit.java
@@ -26,8 +26,7 @@ public class SelfHit extends Check {
     }
 
     public boolean check(final Player damager, final Player damaged, final FightData data, final FightConfig cc){
-        // Check if the Entity Id's are Equals
-        if (damager.getEntityId() != damaged.getEntityId()) return false;
+        if (!damager.getName().equals(damaged.getName())) return false;
 
         boolean cancel = false;
         // Treat self hitting as instant violation.

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/SelfHit.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/SelfHit.java
@@ -26,7 +26,8 @@ public class SelfHit extends Check {
     }
 
     public boolean check(final Player damager, final Player damaged, final FightData data, final FightConfig cc){
-        if (!damager.getName().equals(damaged.getName())) return false;
+        // Check if the Entity Id's are Equals
+        if (damager.getEntityId() != damaged.getEntityId()) return false;
 
         boolean cancel = false;
         // Treat self hitting as instant violation.

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
@@ -65,7 +65,7 @@ import fr.neatmonster.nocheatplus.utilities.InventoryUtil;
  * 
  * @see InventoryEvent
  */
-public class InventoryListener  extends CheckListener implements JoinLeaveListener{
+public class InventoryListener extends CheckListener implements JoinLeaveListener{
 
     /** The drop check. */
     private final Drop       drop       = addCheck(new Drop());

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/EqualsRotate.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/EqualsRotate.java
@@ -1,0 +1,24 @@
+package fr.neatmonster.nocheatplus.checks.net;
+
+import fr.neatmonster.nocheatplus.checks.Check;
+import fr.neatmonster.nocheatplus.checks.CheckType;
+import fr.neatmonster.nocheatplus.players.DataManager;
+import fr.neatmonster.nocheatplus.utilities.CheckUtils;
+import org.bukkit.entity.Player;
+
+public class EqualsRotate extends Check {
+
+    public EqualsRotate() {
+        super(CheckType.NET_EQUALSROTATE);
+    }
+
+    public boolean check(final Player player, final NetData data, final NetConfig cc, float yaw, float pitch) {
+        if (yaw == data.lastYaw && pitch == data.lastPitch && !CheckUtils.hasBypass(CheckType.NET_KEEPALIVEFREQUENCY, player, DataManager.getPlayerData(player))) {
+            data.equalsRotateVio++;
+            if (executeActions(player, data.equalsRotateVio, 1, cc.equalsRotateActions).willCancel())
+                return true;
+        }
+        data.equalsRotateVio = Math.max(0, data.equalsRotateVio-0.02);
+        return false;
+    }
+}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/EqualsRotate.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/EqualsRotate.java
@@ -12,13 +12,24 @@ public class EqualsRotate extends Check {
         super(CheckType.NET_EQUALSROTATE);
     }
 
-    public boolean check(final Player player, final NetData data, final NetConfig cc, float yaw, float pitch) {
+    public boolean check(final long time, final Player player, final NetData data, final NetConfig cc, float yaw, float pitch) {
         if (yaw == data.lastYaw && pitch == data.lastPitch && !CheckUtils.hasBypass(CheckType.NET_KEEPALIVEFREQUENCY, player, DataManager.getPlayerData(player))) {
+            //Check for Teleports
+            final long teleportDelay = time-data.lastTeleport;
+            if(!data.teleportUsed && teleportDelay < 5000){
+                data.teleportUsed = true;
+                return false;
+            }
             data.equalsRotateVio++;
             if (executeActions(player, data.equalsRotateVio, 1, cc.equalsRotateActions).willCancel())
                 return true;
         }
         data.equalsRotateVio = Math.max(0, data.equalsRotateVio-0.02);
         return false;
+    }
+
+    public void handleTeleport(long time, NetData data){
+        data.teleportUsed = false;
+        data.lastTeleport = time;
     }
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetConfig.java
@@ -36,6 +36,7 @@ public class NetConfig extends ACheckConfig {
             Permissions.NET_FLYINGFREQUENCY, 
             Permissions.NET_KEEPALIVEFREQUENCY,
             Permissions.NET_PACKETFREQUENCY,
+            Permissions.NET_EQUALSROTATE
     };
 
     public static RegisteredPermission[] getPreferKeepUpdatedPermissions() {
@@ -77,6 +78,9 @@ public class NetConfig extends ACheckConfig {
 
     public final boolean supersededFlyingCancelWaiting;
 
+    public final boolean equalsRotateActive;
+    public final ActionList equalsRotateActions;
+
     public NetConfig(final ConfigFile config) {
         // TODO: These permissions should have default policies.
         super(config, ConfPaths.NET);
@@ -114,6 +118,8 @@ public class NetConfig extends ACheckConfig {
 
         supersededFlyingCancelWaiting = config.getBoolean(ConfPaths.NET_SUPERSEDED_FLYING_CANCELWAITING);
 
+        equalsRotateActive = config.getBoolean(ConfPaths.NET_EQALSROTATE_ACTIVE);
+        equalsRotateActions = config.getOptimizedActionList(ConfPaths.NET_EQALSROTATE_ACTIONS, Permissions.NET_EQUALSROTATE);
     }
 
     @Override
@@ -129,6 +135,8 @@ public class NetConfig extends ACheckConfig {
                 return soundDistanceActive;
             case NET_KEEPALIVEFREQUENCY:
                 return keepAliveFrequencyActive;
+            case NET_EQUALSROTATE:
+                return equalsRotateActive;
             default:
                 return true;
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetData.java
@@ -88,6 +88,14 @@ public class NetData extends ACheckData {
      */
     private long maxSequence = 0;
 
+    /*
+     * For the EqualsRotation check
+     * Last Yaw and Pitch
+     * Updated when a POSITION_LOOK or LOOK packet comes in
+     */
+    public float lastYaw = -1, lastPitch = -1;
+    public double equalsRotateVio = 0;
+
     /** Overall packet frequency. */
     public final ActionFrequency packetFrequency;
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetData.java
@@ -95,6 +95,8 @@ public class NetData extends ACheckData {
      */
     public float lastYaw = -1, lastPitch = -1;
     public double equalsRotateVio = 0;
+    public long lastTeleport = 0;
+    public boolean teleportUsed = true;
 
     /** Overall packet frequency. */
     public final ActionFrequency packetFrequency;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetListener.java
@@ -1,0 +1,26 @@
+package fr.neatmonster.nocheatplus.checks.net;
+
+import fr.neatmonster.nocheatplus.checks.CheckListener;
+import fr.neatmonster.nocheatplus.checks.CheckType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.PlayerTeleportEvent;
+
+public class NetListener extends CheckListener {
+
+    public NetListener() {
+        super(CheckType.NET);
+    }
+
+    public final EqualsRotate equalsRotate = new EqualsRotate();
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
+    public void onTeleport(final PlayerTeleportEvent event){
+        final long time = System.currentTimeMillis();
+        final Player player = event.getPlayer();
+        final NetData data = (NetData) CheckType.NET.getDataFactory().getData(player);
+        //final NetConfig config = (NetConfig) CheckType.NET.getConfigFactory().getConfig(player);
+        equalsRotate.handleTeleport(time, data);
+    }
+}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
@@ -748,6 +748,10 @@ public abstract class ConfPaths {
     private static final String NET_SUPERSEDED_FLYING                       = NET_SUPERSEDED + "flying.";
     public static final String  NET_SUPERSEDED_FLYING_CANCELWAITING         = NET_SUPERSEDED_FLYING + "cancelwaiting";
 
+    private static final String NET_EQALSROTATE                             = NET + "equalsrotate.";
+    public static final String  NET_EQALSROTATE_ACTIVE                      = NET_EQALSROTATE + "active";
+    public static final String  NET_EQALSROTATE_ACTIONS                     = NET_EQALSROTATE + "actions";
+
     public static final String  STRINGS                                     = "strings";
 
     // Compatibility section (possibly temporary).

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/Permissions.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/Permissions.java
@@ -160,6 +160,8 @@ public class Permissions {
     public static final RegisteredPermission  NET_FLYINGFREQUENCY          = add(NET + ".flyingfrequency");
     public static final RegisteredPermission  NET_KEEPALIVEFREQUENCY       = add(NET + ".keepalivefrequency");
     public static final RegisteredPermission  NET_PACKETFREQUENCY          = add(NET + ".packetfrequency");
+    public static final RegisteredPermission  NET_EQUALSROTATE          = add(NET + ".equalsrotate");
+
 
     public static final RegisteredPermission  MOVING                       = add(CHECKS + ".moving");
     public static final RegisteredPermission  MOVING_CREATIVEFLY           = add(MOVING + ".creativefly");

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
@@ -30,6 +30,7 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
 
+import fr.neatmonster.nocheatplus.checks.net.NetListener;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -961,6 +962,7 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
                 new FightListener(),
                 new InventoryListener(),
                 new MovingListener(),
+                new NetListener(),
         }) {
             addComponent(obj);
             // Register sub-components (allow later added to use registries, if any).

--- a/NCPPlugin/src/main/resources/plugin.yml
+++ b/NCPPlugin/src/main/resources/plugin.yml
@@ -315,6 +315,8 @@ permissions:
                   description: Bypass the KeepAliveFrequency check (keep alive packet spam).
                 nocheatplus.checks.net.packetfrequency:
                   description: Bypass the PacketFrequency check (overall packet spam).
+                nocheatplus.checks.net.equalsrotate:
+                                  description: Bypass the EqualsRotate check (illegal rotations).
     
     nocheatplus.mods:
         description: Allow the player to use all the client mods.


### PR DESCRIPTION
There are 3 Types of Move Packets that a Player can send.
C06PacketPlayerPosLook
C04PacketPlayerPosition
C05PacketPlayerLook
PosLook and Look will only be send if the Yaw or the Pitch changed.
EqualsRotate will check if the Yaw or the Pitch changed.
What will the check prevent?
Some Clients don't care about this Rule.
It can Prevent Tomer, Scaffold, Killaura, Aimassist, BowAimbot and so on.
