### PR TITLE
Manual sf vl cooldown

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingConfig.java
@@ -176,12 +176,17 @@ public class MovingConfig extends ACheckConfig {
      * normal speed on 1.6.4 and probably below.
      */
     public final boolean    sfGroundHop;
+    public final double     sfStepHeight;
     public final boolean    survivalFlyAccountingH;
     public final boolean    survivalFlyAccountingV;
+    // Leniency settings.
+    /** Horizontal buffer (rather sf), after failure leniency. */
+    public final double hBufMax;
+    public final long       survivalFlyVLFreeze; // TODO: Rename to FreezeTime.
+    public final boolean    survivalFlyVLFreezeInAir;
+    // Set back policy.
     public final boolean    sfSetBackPolicyVoid;
     public final boolean    sfSetBackPolicyFallDamage;
-    public final double     sfStepHeight;
-    public final long       survivalFlyVLFreeze;
     public final ActionList survivalFlyActions;
 
     public final boolean 	sfHoverCheck;
@@ -191,8 +196,6 @@ public class MovingConfig extends ACheckConfig {
     public final double		sfHoverViolation;
 
     // Special tolerance values:
-    /** Horizontal buffer (rather sf), after failure leniency. */
-    public final double hBufMax;
     /**
      * Number of moving packets until which a velocity entry must be activated,
      * in order to not be removed.
@@ -327,7 +330,9 @@ public class MovingConfig extends ACheckConfig {
         } else {
             this.sfStepHeight = sfStepHeight;
         }
-        survivalFlyVLFreeze = config.getLong(ConfPaths.MOVING_SURVIVALFLY_VLFREEZE, 2000L);
+        hBufMax = config.getDouble(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_HBUFMAX);
+        survivalFlyVLFreeze = config.getLong(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_FREEZETIME);
+        survivalFlyVLFreezeInAir = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_FREEZEINAIR);
         survivalFlyActions = config.getOptimizedActionList(ConfPaths.MOVING_SURVIVALFLY_ACTIONS, Permissions.MOVING_SURVIVALFLY);
 
         sfHoverCheck = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_HOVER_CHECK);
@@ -336,7 +341,6 @@ public class MovingConfig extends ACheckConfig {
         sfHoverFallDamage = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_HOVER_FALLDAMAGE);
         sfHoverViolation = config.getDouble(ConfPaths.MOVING_SURVIVALFLY_HOVER_SFVIOLATION);
 
-        hBufMax = config.getDouble(ConfPaths.MOVING_SURVIVALFLY_HBUFMAX);
         velocityActivationCounter = config.getInt(ConfPaths.MOVING_VELOCITY_ACTIVATIONCOUNTER);
         velocityActivationTicks = config.getInt(ConfPaths.MOVING_VELOCITY_ACTIVATIONTICKS);
         velocityStrictInvalidation = config.getBoolean(ConfPaths.MOVING_VELOCITY_STRICTINVALIDATION);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
@@ -509,14 +509,16 @@ public class SurvivalFly extends Check {
         }
         else {
             // Slowly reduce the level with each event, if violations have not recently happened.
-            if (now - data.sfVLTime > cc.survivalFlyVLFreeze) {
+            // TODO: Switch to move count instead of time (!).
+            if (now - data.sfVLTime > cc.survivalFlyVLFreeze 
+                && (!cc.survivalFlyVLFreezeInAir || !Magic.inAir(thisMove))) {
+                // Relax VL.
                 data.survivalFlyVL *= 0.95D;
-            }
-
-            // Finally check horizontal buffer regain.
-            if (hDistanceAboveLimit < 0.0  && result <= 0.0 && !isSamePos && data.sfHorizontalBuffer < cc.hBufMax) {
-                // TODO: max min other conditions ?
-                hBufRegain(hDistance, Math.min(0.2, Math.abs(hDistanceAboveLimit)), data, cc);
+                // Finally check horizontal buffer regain.
+                if (hDistanceAboveLimit < 0.0  && result <= 0.0 && !isSamePos && data.sfHorizontalBuffer < cc.hBufMax) {
+                    // TODO: max min other conditions ?
+                    hBufRegain(hDistance, Math.min(0.2, Math.abs(hDistanceAboveLimit)), data, cc);
+                }
             }
         }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
@@ -634,15 +634,17 @@ public abstract class ConfPaths {
     public static final String MOVING_SURVIVALFLY_COBWEBHACK                = MOVING_SURVIVALFLY + "cobwebhack";
     public static final String MOVING_SURVIVALFLY_SLOWNESSSPRINTHACK        = MOVING_SURVIVALFLY + "slownesssprinthack";
     public static final String MOVING_SURVIVALFLY_GROUNDHOP                 = MOVING_SURVIVALFLY + "groundhop";
+    public static final String MOVING_SURVIVALFLY_STEPHEIGHT                = MOVING_SURVIVALFLY + "stepheight";
     private static final String MOVING_SURVIVALFLY_EXTENDED                 = MOVING_SURVIVALFLY + "extended.";
     public static final String MOVING_SURVIVALFLY_EXTENDED_HACC             = MOVING_SURVIVALFLY_EXTENDED + "horizontal-accounting";
     public static final String MOVING_SURVIVALFLY_EXTENDED_VACC             = MOVING_SURVIVALFLY_EXTENDED + "vertical-accounting";
+    private static final String MOVING_SURVIVALFLY_LENIENCY                 = MOVING_SURVIVALFLY + "leniency.";
+    public static final String  MOVING_SURVIVALFLY_LENIENCY_HBUFMAX         = MOVING_SURVIVALFLY_LENIENCY + "hbufmax";
+    public static final String  MOVING_SURVIVALFLY_LENIENCY_FREEZETIME      = MOVING_SURVIVALFLY_LENIENCY + "freezetime";
+    public static final String  MOVING_SURVIVALFLY_LENIENCY_FREEZEINAIR     = MOVING_SURVIVALFLY_LENIENCY + "freezeinair";
     private static final String MOVING_SURVIVALFLY_SETBACKPOLICY            = MOVING_SURVIVALFLY + "setbackpolicy.";
     public static final String MOVING_SURVIVALFLY_SETBACKPOLICY_FALLDAMAGE  = MOVING_SURVIVALFLY_SETBACKPOLICY + "falldamage";
     public static final String MOVING_SURVIVALFLY_SETBACKPOLICY_VOIDTOVOID  = MOVING_SURVIVALFLY_SETBACKPOLICY + "voidtovoid";
-    public static final String MOVING_SURVIVALFLY_STEPHEIGHT                = MOVING_SURVIVALFLY + "stepheight";
-    public static final String MOVING_SURVIVALFLY_HBUFMAX                   = MOVING_SURVIVALFLY + "hbufmax";
-    public static final String MOVING_SURVIVALFLY_VLFREEZE                  = MOVING_SURVIVALFLY + "vlfreeze";
     public static final String MOVING_SURVIVALFLY_ACTIONS                   = MOVING_SURVIVALFLY + "actions";
 
     @GlobalConfig
@@ -827,6 +829,10 @@ public abstract class ConfPaths {
     public static final String  MOVING_MOREPACKETSVEHICLE_CHECK          = "checks.moving.morepacketsvehicle.active";
     @Moved(newPath=MOVING_VEHICLE_MOREPACKETS_ACTIONS)
     public static final String  MOVING_MOREPACKETSVEHICLE_ACTIONS        = "checks.moving.morepacketsvehicle.actions";
+    @Moved(newPath=MOVING_SURVIVALFLY_LENIENCY_HBUFMAX)
+    public static final String MOVING_SURVIVALFLY_HBUFMAX                = "checks.moving.survivalfly.hbufmax";
+    @Moved(newPath=MOVING_SURVIVALFLY_LENIENCY_FREEZETIME)
+    public static final String MOVING_SURVIVALFLY_VLFREEZE               = "checks.moving.survivalfly.vlfreeze";
     // Deprecated paths (just removed).
     @Deprecated
     public static final String  MISCELLANEOUS_REPORTTOMETRICS            = "miscellaneous.reporttometrics";

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
@@ -645,9 +645,9 @@ public abstract class ConfPaths {
     public static final String MOVING_SURVIVALFLY_VLFREEZE                  = MOVING_SURVIVALFLY + "vlfreeze";
     public static final String MOVING_SURVIVALFLY_ACTIONS                   = MOVING_SURVIVALFLY + "actions";
 
-    private static final String MOVING_SURVIVALFLY_HOVER                    = MOVING_SURVIVALFLY + "hover.";
-    public static final String  MOVING_SURVIVALFLY_HOVER_CHECK              = MOVING_SURVIVALFLY_HOVER + "active";
     @GlobalConfig
+    public static final String  MOVING_SURVIVALFLY_HOVER                    = MOVING_SURVIVALFLY + "hover.";
+    public static final String  MOVING_SURVIVALFLY_HOVER_CHECK              = MOVING_SURVIVALFLY_HOVER + "active";
     public static final String  MOVING_SURVIVALFLY_HOVER_STEP               = MOVING_SURVIVALFLY_HOVER + "step";
     public static final String  MOVING_SURVIVALFLY_HOVER_TICKS              = MOVING_SURVIVALFLY_HOVER + "ticks";
     public static final String  MOVING_SURVIVALFLY_HOVER_LOGINTICKS         = MOVING_SURVIVALFLY_HOVER + "loginticks";
@@ -685,6 +685,7 @@ public abstract class ConfPaths {
     public static final String  MOVING_TRACE_MAXAGE                         = MOVING_TRACE + "maxage";
     public static final String  MOVING_TRACE_MAXSIZE                        = MOVING_TRACE + "maxsize";
 
+    // Vehicles.
     private static final String MOVING_VEHICLE                              = MOVING + "vehicle.";
     public static final String  MOVING_VEHICLE_ENFORCELOCATION              = MOVING_VEHICLE + "enforcelocation";
     public static final String  MOVING_VEHICLE_PREVENTDESTROYOWN            = MOVING_VEHICLE + "preventdestroyown";
@@ -695,7 +696,7 @@ public abstract class ConfPaths {
     public static final String  MOVING_VEHICLE_MOREPACKETS_ACTIONS          = MOVING_VEHICLE_MOREPACKETS + "actions";
     private static final String MOVING_VEHICLE_ENVELOPE                     = MOVING_VEHICLE + "envelope.";
     public static final String  MOVING_VEHICLE_ENVELOPE_ACTIVE              = MOVING_VEHICLE_ENVELOPE + "active";
-    public static final String  MOVING_VEHICLE_ENVELOPE_HSPEEDCAP              = MOVING_VEHICLE_ENVELOPE + "hdistcap"; // Section.
+    public static final String  MOVING_VEHICLE_ENVELOPE_HSPEEDCAP           = MOVING_VEHICLE_ENVELOPE + "hdistcap"; // Section.
     public static final String  MOVING_VEHICLE_ENVELOPE_ACTIONS             = MOVING_VEHICLE_ENVELOPE + "actions";
 
     private static final String MOVING_MESSAGE                              = MOVING + "message.";

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
@@ -454,9 +454,11 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.MOVING_PASSABLE_UNTRACKED_CMD_PREFIXES, Arrays.asList("sethome", "home set", "setwarp", "warp set", "setback", "set back", "back set"), 785);
 
         set(ConfPaths.MOVING_SURVIVALFLY_CHECK, true, 785);
-        set(ConfPaths.MOVING_SURVIVALFLY_EXTENDED_VACC, true, 785);
         set(ConfPaths.MOVING_SURVIVALFLY_STEPHEIGHT, "default", 785);
-        set(ConfPaths.MOVING_SURVIVALFLY_HBUFMAX, 1.0, 785);
+        set(ConfPaths.MOVING_SURVIVALFLY_EXTENDED_VACC, true, 785);
+        set(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_HBUFMAX, 1.0, 1143);
+        set(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_FREEZETIME, 2000, 1143);
+        set(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_FREEZEINAIR, true, 1143);
         set(ConfPaths.MOVING_SURVIVALFLY_SETBACKPOLICY_FALLDAMAGE, true, 785);
         set(ConfPaths.MOVING_SURVIVALFLY_SETBACKPOLICY_VOIDTOVOID, true, 785);
         set(ConfPaths.MOVING_SURVIVALFLY_ACTIONS, 


### PR DESCRIPTION
1. Add option to not relax the VL with in-air moves (active by default).
2. Expose vl freeze time (altered config paths).
3. Only allow hbuf regain if not frozen.

This'll make stuff stricter for the default config too (hbuf regain), intention is to fix survivalfly anyway :p. This PR aims at making custom survivalfly actions llike  "actions: vl>45 ..." less dangerous.